### PR TITLE
change color and layout of jsconf logo

### DIFF
--- a/css/_components.jsconfeu.css
+++ b/css/_components.jsconfeu.css
@@ -1,9 +1,10 @@
 .c-jsconfeu {
-  max-width: 30rem;
+  max-width: 24rem;
 }
 
 .svg-jsconfeu-logo-2017 {
   display: block;
   width: 100%;
   max-height: 5.625rem;
+  fill: #E10079;
 }


### PR DESCRIPTION
Tiny change, just made the jsconf logo pink and a bit smaller.
