### PR TITLE
Fix displaying 2015's sponsors logos

### DIFF
--- a/css/_base.page.css
+++ b/css/_base.page.css
@@ -79,3 +79,7 @@ section {
   height: 100%;
   padding: 1.75rem 2rem 2rem;
 }
+
+.box--sponsor-2015 .svg {
+  display: block;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "2017-assets",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "This module contains all assets for the 2017 CSSconf EU websites.",
   "main": "README.md",
   "author": "CSSconf EU",


### PR DESCRIPTION
Turned out applying `display: block` to the `<svg>` fixed the problem with svgs being weirdly scaled on Safari 10.
